### PR TITLE
Add base app layout with form and menu

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -5,16 +5,17 @@ function createWindow() {
   const win = new BrowserWindow({
     width: 1200,
     height: 800,
-    webPreferences: {
-      preload: path.join(__dirname, 'preload.js'),
-    },
     frame: false,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
   });
 
-  win.loadURL(
+  const startURL =
     process.env.ELECTRON_START_URL ||
-      `file://${path.join(__dirname, '../public/index.html')}`
-  );
+    `file://${path.join(__dirname, '../dist/index.html')}`;
+  win.loadURL(startURL);
 
   const template = [
     {
@@ -27,10 +28,16 @@ function createWindow() {
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
 
-  ipcMain.on('window-control', (_, action) => {
-    if (action === 'minimize') win.minimize();
-    if (action === 'maximize') win.isMaximized() ? win.unmaximize() : win.maximize();
-    if (action === 'close') win.close();
+  ipcMain.on('minimize', () => {
+    win.minimize();
+  });
+
+  ipcMain.on('maximize', () => {
+    win.isMaximized() ? win.unmaximize() : win.maximize();
+  });
+
+  ipcMain.on('close', () => {
+    win.close();
   });
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,24 @@ import FormSection from './components/FormSection';
 import PDFPreview from './components/PDFPreview';
 import MenuBar from './components/MenuBar';
 
+interface FormData {
+  certificadoNo: string;
+  fecha: string;
+  cliente: string;
+  orden: string;
+  instrumento: string;
+  fabricante: string;
+}
+
 const App: React.FC = () => {
-  const [data, setData] = useState({});
+  const [data, setData] = useState<FormData>({
+    certificadoNo: '',
+    fecha: '',
+    cliente: '',
+    orden: '',
+    instrumento: '',
+    fabricante: '',
+  });
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
 
   useEffect(() => {
@@ -15,10 +31,12 @@ const App: React.FC = () => {
   }, []);
 
   return (
-    <div className="flex h-full">
+    <div className="h-full flex flex-col">
       <MenuBar lastSaved={lastSaved} />
-      <FormSection data={data} onChange={setData} />
-      <PDFPreview data={data} />
+      <div className="flex flex-1">
+        <FormSection data={data} onChange={setData} />
+        <PDFPreview data={data} />
+      </div>
     </div>
   );
 };

--- a/src/components/FormSection.tsx
+++ b/src/components/FormSection.tsx
@@ -1,19 +1,102 @@
-import React from 'react';
+import React, { useState } from 'react';
+
+interface FormData {
+  certificadoNo: string;
+  fecha: string;
+  cliente: string;
+  orden: string;
+  instrumento: string;
+  fabricante: string;
+}
 
 interface Props {
-  data: any;
-  onChange: (data: any) => void;
+  data: FormData;
+  onChange: (data: FormData) => void;
 }
 
 const FormSection: React.FC<Props> = ({ data, onChange }) => {
+  const [disabled, setDisabled] = useState(false);
+
+  const handleChange = (field: keyof FormData, value: string) => {
+    onChange({ ...data, [field]: value });
+  };
+
+  const handleLastKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Tab' && !e.shiftKey) {
+      setDisabled(true);
+    }
+  };
+
   return (
-    <form className="flex-1 p-4 overflow-y-auto">
-      {/* TODO: Implement form fields */}
-      <input
-        className="border p-2 w-full"
-        placeholder="Dato de ejemplo"
-        onChange={(e) => onChange({ ...data, field: e.target.value })}
-      />
+    <form
+      className={`flex-1 p-4 overflow-y-auto ${disabled ? 'opacity-50 pointer-events-none' : ''}`}
+    >
+      <label className="block mb-3">
+        <span className="text-sm">Certificado N°</span>
+        <input
+          type="text"
+          className="border p-2 w-full"
+          value={data.certificadoNo}
+          onChange={(e) => handleChange('certificadoNo', e.target.value)}
+          disabled={disabled}
+        />
+      </label>
+
+      <label className="block mb-3">
+        <span className="text-sm">Fecha de calibración</span>
+        <input
+          type="date"
+          className="border p-2 w-full"
+          value={data.fecha}
+          onChange={(e) => handleChange('fecha', e.target.value)}
+          disabled={disabled}
+        />
+      </label>
+
+      <label className="block mb-3">
+        <span className="text-sm">Cliente</span>
+        <input
+          type="text"
+          className="border p-2 w-full"
+          value={data.cliente}
+          onChange={(e) => handleChange('cliente', e.target.value)}
+          disabled={disabled}
+        />
+      </label>
+
+      <label className="block mb-3">
+        <span className="text-sm">Orden de compra</span>
+        <input
+          type="text"
+          className="border p-2 w-full"
+          value={data.orden}
+          onChange={(e) => handleChange('orden', e.target.value)}
+          disabled={disabled}
+        />
+      </label>
+
+      <label className="block mb-3">
+        <span className="text-sm">Instrumento</span>
+        <input
+          type="text"
+          className="border p-2 w-full"
+          value={data.instrumento}
+          onChange={(e) => handleChange('instrumento', e.target.value)}
+          disabled={disabled}
+        />
+      </label>
+
+      <label className="block mb-3">
+        <span className="text-sm">Fabricante</span>
+        <input
+          type="text"
+          className="border p-2 w-full"
+          value={data.fabricante}
+          onChange={(e) => handleChange('fabricante', e.target.value)}
+          onKeyDown={handleLastKey}
+          disabled={disabled}
+        />
+      </label>
     </form>
   );
 };

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -6,18 +6,21 @@ interface Props {
 }
 
 const MenuBar: React.FC<Props> = ({ lastSaved }) => {
-  const send = (action: string) => ipcRenderer.send('window-control', action);
+  const send = (channel: 'minimize' | 'maximize' | 'close') => {
+    ipcRenderer.send(channel);
+  };
 
   return (
-    <header className="w-full flex items-center justify-between bg-gray-800 text-white p-2">
-      <div>
-        <button onClick={() => send('minimize')}>_</button>
-        <button onClick={() => send('maximize')}>[]</button>
-        <button onClick={() => send('close')}>X</button>
-      </div>
-      <span className="text-sm mr-2">
+    <header className="w-full flex items-center justify-between bg-gray-800 text-white p-2 select-none">
+      <span className="mr-4">Archivo</span>
+      <span className="text-sm flex-1">
         Último guardado: {lastSaved ? lastSaved.toLocaleTimeString() : 'Nunca'}
       </span>
+      <div className="space-x-2">
+        <button onClick={() => send('minimize')} className="px-2">_</button>
+        <button onClick={() => send('maximize')} className="px-2">⬜</button>
+        <button onClick={() => send('close')} className="px-2">X</button>
+      </div>
     </header>
   );
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles/tailwind.css';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  ReactDOM.createRoot(rootElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}


### PR DESCRIPTION
## Summary
- update app layout and state management
- implement menu bar controls and last saved display
- build out initial form with required fields and disable on tabbing past last field

## Testing
- `npm run build` *(fails: cannot find React/Electron type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683fb1a50da88323bb9c04033bfc282e