### PR TITLE
Fix electron start race

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ npm install
 npm run start
 ```
 
+El script de inicio ahora espera a que el servidor de desarrollo de Vite esté disponible antes de lanzar Electron, evitando la ventana en blanco si el navegador se abre demasiado pronto.
+
 ## Compilación
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "main": "electron/main.js",
   "scripts": {
-    "start": "concurrently \"npm:react\" \"npm:electron\"",
+    "start": "concurrently \"npm:react\" \"npm:wait-electron\"",
     "react": "vite",
+    "wait-electron": "wait-on http://localhost:5173 && npm run electron",
     "electron": "cross-env ELECTRON_START_URL=http://localhost:5173 electron .",
     "build": "tsc && vite build"
   },
@@ -18,6 +19,7 @@
     "@vitejs/plugin-react": "^4.5.1",
     "concurrently": "^8.0.0",
     "cross-env": "^7.0.3",
+    "wait-on": "^7.0.1",
     "typescript": "^5.0.0",
     "vite": "^4.3.0"
   }


### PR DESCRIPTION
## Summary
- fix start script to wait for Vite server
- add `wait-on` as dev dependency
- update README about start behaviour

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_683fb7b84e388323b8dc406b763ac8db